### PR TITLE
Fix hierarchical sorting of ships

### DIFF
--- a/ui/src/lib/stores/patp.js
+++ b/ui/src/lib/stores/patp.js
@@ -63,9 +63,25 @@ function tieredAlphabeticalSort(ships) {
   });
 }
 
+function tierSplit(ship) {
+  const galaxy = ship.slice(-3);
+  const starPart = ship.slice(-6, -3);
+  const planetPart = ship.slice(-13, -7);
+  const moonPart = ship.slice(0, -14);
+  return [ moonPart, planetPart, starPart, galaxy ];
+}
+
+function tierJoin(parts) {
+  const [ moonPart, planetPart, starPart, galaxy ] = parts;
+  return `${moonPart}-${planetPart}-${starPart}${galaxy}`.replace(/^-*/, '');
+}
+
 function hierarchicalSort(ships) {
-  // In this case, hierarchical sorting is the same as tiered alphabetical sorting
-  return tieredAlphabeticalSort(ships);
+  const reversed = ships.map(ship => {
+    return tierSplit(ship).reverse().join('.');
+  });
+  const sorted = reversed.sort()
+  return sorted.map(string => tierJoin(string.split('.').reverse()));
 }
 
 export const sortModes = {

--- a/ui/src/routes/(home)/+page.svelte
+++ b/ui/src/routes/(home)/+page.svelte
@@ -3,9 +3,12 @@
   import NewShipCard from "./NewShipCard.svelte"
   import { wide } from '$lib/stores/display'
   import { structure } from '$lib/stores/websocket'
+  import { sortModes } from '$lib/stores/patp'
 
+  const sortMode = 'hierarchical'
+  
   $: urbits = ($structure?.urbits) || {}
-  $: ships = Object.keys(urbits)
+  $: ships = sortModes[sortMode](Object.keys(urbits))
 
 </script>
 


### PR DESCRIPTION
Reimplemented hierarchical sort which should be a bit more obvious what's going on, and doesn't have a bug the previous version had.